### PR TITLE
Add Ruff LSP for Python Linting

### DIFF
--- a/lsp/ruff.lua
+++ b/lsp/ruff.lua
@@ -1,0 +1,17 @@
+return {
+  -- Command to start the ruff LSP server.
+  cmd = { 'ruff', 'server' },
+
+  -- Filetypes to automatically attach to.
+  filetypes = { 'python' },
+
+  -- Root directory markers for Python projects.
+  root_markers = { 'pyproject.toml', 'ruff.toml', '.ruff.toml', '.git' },
+
+  -- Match pyrefly's position encoding to avoid cross-client warnings.
+  capabilities = {
+    general = {
+      positionEncodings = { 'utf-16' },
+    },
+  },
+}

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -8,6 +8,7 @@
 -- so in ~.config/lsp/lua_ls.lua for lua_ls, for example.
 vim.lsp.enable('lua_ls')
 vim.lsp.enable('pyrefly')
+vim.lsp.enable('ruff')
 
 vim.api.nvim_create_autocmd('LspAttach', {
   callback = function(ev)


### PR DESCRIPTION
Tasks:
- Add `lsp/ruff.lua` config with `ruff server` command and root markers
- Enable ruff via `vim.lsp.enable('ruff')` in `lua/config/lsp.lua`
- Fix position encoding mismatch between pyrefly (UTF-16) and ruff by forcing ruff to use UTF-16 in capabilities