### PR TITLE
Add TypeScript LSP

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'typescript-language-server', '--stdio' },
+  filetypes = { 'typescript', 'typescriptreact', 'javascript', 'javascriptreact' },
+  root_markers = { 'tsconfig.json', 'jsconfig.json', 'package.json', '.git' },
+}

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -9,6 +9,7 @@
 vim.lsp.enable('lua_ls')
 vim.lsp.enable('pyrefly')
 vim.lsp.enable('ruff')
+vim.lsp.enable('ts_ls')
 
 vim.api.nvim_create_autocmd('LspAttach', {
   callback = function(ev)
@@ -29,8 +30,8 @@ vim.diagnostic.config({
   -- virtual_lines = true
 
   -- Alternatively, customize specific options
-  virtual_lines = {
-    -- Only show virtual line diagnostics for the current cursor line
+  virtual_text = {
+    -- Only show virtual text diagnostics for the current cursor line
     current_line = true,
   },
 })


### PR DESCRIPTION
Tasks:
- Add `lsp/ts_ls.lua` config with `typescript-language-server --stdio` command and root markers
- Enable ts_ls via `vim.lsp.enable('ts_ls')` in `lua/config/lsp.lua`
- Fix diagnostic config to use `virtual_text` instead of `virtual_lines` for current-line-only display