### PR TITLE
Add Terraform LSP

### DIFF
--- a/lsp/terraform_ls.lua
+++ b/lsp/terraform_ls.lua
@@ -1,0 +1,9 @@
+return {
+  cmd = { 'terraform-ls', 'serve' },
+
+  filetypes = { 'terraform', 'terraform-vars' },
+
+  root_markers = { '.terraform', '.git' },
+
+  settings = {},
+}

--- a/lsp/terraform_ls.lua
+++ b/lsp/terraform_ls.lua
@@ -1,7 +1,7 @@
 return {
   cmd = { 'terraform-ls', 'serve' },
 
-  filetypes = { 'terraform', 'terraform-vars' },
+  filetypes = { 'terraform' },
 
   root_markers = { '.terraform', '.git' },
 

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -10,6 +10,7 @@ vim.lsp.enable('lua_ls')
 vim.lsp.enable('pyrefly')
 vim.lsp.enable('ruff')
 vim.lsp.enable('ts_ls')
+vim.lsp.enable('terraform_ls')
 
 vim.api.nvim_create_autocmd('LspAttach', {
   callback = function(ev)


### PR DESCRIPTION
## Summary
- Add `lsp/terraform_ls.lua` config for `terraform-ls` (HashiCorp Terraform language server)
- Enable `terraform_ls` in `lua/config/lsp.lua`

## Install
```sh
brew install hashicorp/tap/terraform-ls
```

## Test plan
- [x] Run `terraform init` in a Terraform project to create `.terraform/`
- [x] Open a `.tf` file and verify LSP attaches (`:checkhealth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)