### PR TITLE
Add Catppuccin theme via vim.pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,16 @@
 # Neovim Config
 
-A minimal, zero-plugin Neovim configuration using native LSP, completion, and diagnostics (Neovim 0.11+). No plugin manager — only built-in Neovim features.
+A minimal Neovim configuration using native LSP, completion, and diagnostics (Neovim 0.11+). Plugins are managed via the built-in `vim.pack.add()` API — no external plugin manager.
 
 ## Directory Structure
 
 ```
 init.lua                  # Entry point — loads modules in order
+nvim-pack-lock.json       # Lockfile pinning installed plugin revisions
 lua/config/
   globals.lua             # Leader key and global settings
+  plugins.lua             # Plugin declarations via vim.pack.add
+  theme.lua               # Colorscheme configuration
   options.lua             # Editor options
   keymap.lua              # Key mappings
   autocmd.lua             # Autocommands
@@ -24,7 +27,7 @@ lsp/
 
 Modules are loaded sequentially in `init.lua`:
 ```
-globals → options → keymap → autocmd → lsp
+globals → plugins → theme → options → keymap → autocmd → lsp
 ```
 
 LSP servers are configured in individual files under `lsp/` and enabled in `lua/config/lsp.lua` via `vim.lsp.enable()`. See the [Neovim 0.11 LSP overview](https://gpanders.com/blog/whats-new-in-neovim-0-11/) for how this works.
@@ -34,8 +37,16 @@ LSP servers are configured in individual files under `lsp/` and enabled in `lua/
 1. Create `lsp/<server_name>.lua` — use `lsp/lua_ls.lua` as a template. Include `cmd`, `filetypes`, `root_markers`, and `settings`.
 2. Add `vim.lsp.enable('<server_name>')` to `lua/config/lsp.lua`.
 
+## Adding a New Plugin
+
+1. Add an entry to `lua/config/plugins.lua` via `vim.pack.add`.
+2. Plugins install to `~/.local/share/nvim/site/pack/core/opt/` on first launch.
+3. The `nvim-pack-lock.json` lockfile is updated automatically.
+
 ## Conventions
 
+- **Plugins** → `lua/config/plugins.lua`
+- **Colorscheme** → `lua/config/theme.lua`
 - **Keymaps** → `lua/config/keymap.lua`
 - **Options** → `lua/config/options.lua`
 - **Autocommands** → `lua/config/autocmd.lua`

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,6 @@
 require('config.globals')
+require('config.plugins')
+require('config.theme')
 require('config.options')
 require('config.keymap')
 require('config.autocmd')

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -1,0 +1,3 @@
+vim.pack.add({
+  { src = 'https://github.com/catppuccin/nvim', name = 'catppuccin' },
+})

--- a/lua/config/theme.lua
+++ b/lua/config/theme.lua
@@ -1,0 +1,1 @@
+vim.cmd.colorscheme('catppuccin-mocha')

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -1,0 +1,8 @@
+{
+  "plugins": {
+    "catppuccin": {
+      "rev": "426dbebe06b5c69fd846ceb17b42e12f890aedf1",
+      "src": "https://github.com/catppuccin/nvim"
+    }
+  }
+}


### PR DESCRIPTION
Introduces `vim.pack` as the plugin management mechanism for this config and installs the [Catppuccin](https://github.com/catppuccin/nvim) colorscheme (mocha flavor) as the first plugin.

Using the new built-in `vim.pack.add()` API (Neovim 0.12+) keeps the config dependency-free — no plugin manager, no submodules. Plugins clone to `~/.local/share/nvim/site/pack/core/opt/` outside the repo. A `nvim-pack-lock.json` lockfile is generated automatically to pin the installed revision.

Two new modules are added and loaded in `init.lua` before `options`:
- [`lua/config/plugins.lua`](https://github.com/bmkiefer/nvim-config/blob/add-catppuccin-theme/lua/config/plugins.lua) — declares plugins via `vim.pack.add`
- [`lua/config/theme.lua`](https://github.com/bmkiefer/nvim-config/blob/add-catppuccin-theme/lua/config/theme.lua) — sets `catppuccin-mocha` as the colorscheme

🤖 Generated with [Claude Code](https://claude.ai/claude-code)