### PR TITLE
Disable neo-tree / filter keybinding

### DIFF
--- a/lua/config/neo-tree.lua
+++ b/lua/config/neo-tree.lua
@@ -9,5 +9,8 @@ require('neo-tree').setup({
   window = {
     position = 'left',
     width = 35,
+    mappings = {
+      ['/'] = 'noop',
+    },
   },
 })


### PR DESCRIPTION
The built-in neo-tree `/` filter intercepts the key before it can be used as Vim's normal-mode search, which is the more useful behavior in the tree window.

Maps `/` to `noop` in neo-tree's window mappings so the key falls through to normal-mode search.

See [lua/config/neo-tree.lua](../blob/disable-neotree-slash-filter/lua/config/neo-tree.lua) for the change — adds a `mappings` table under `window` with `['/'] = 'noop'`.