### PR TITLE
Add NOTE/TODO comment insertion keymaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ LSP servers are configured in individual files under `lsp/` and enabled in `lua/
 Lua is formatted with [StyLua](https://github.com/JohnnyMorganz/StyLua). Config in `.stylua.toml`:
 - 160 char line width, 2-space indent, single quotes, Unix line endings
 
+## Keymaps
+
+- When suggesting `<leader>`-prefixed mappings, avoid sequences where consecutive keys use the same finger on QWERTY (e.g. `<leader>ct` — both `c` and `t` are left index). Prefer combinations that alternate fingers or hands.
+
 ## Git Workflow
 
 - Never commit directly to `master` — always use a feature branch and open a PR

--- a/lua/config/keymap.lua
+++ b/lua/config/keymap.lua
@@ -2,6 +2,9 @@
 --------------------------------------------------------------------------------
 local gitlink = require('config.gitlink')
 
+local COMMENT_AUTHOR = 'bmkiefer'
+local COMMENT_DATE_FORMAT = '%m-%d-%Y'
+
 -- Navigate visual lines
 vim.keymap.set({ 'n', 'x' }, 'j', 'gj', { desc = 'Navigate down (visual line)' })
 vim.keymap.set({ 'n', 'x' }, 'k', 'gk', { desc = 'Navigate up (visual line)' })
@@ -42,6 +45,27 @@ vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagn
 vim.keymap.set('n', '<leader>xx', '<Cmd>source %<CR>', { desc = 'Source current file' })
 vim.keymap.set('n', '<leader>x', '<Cmd>:.lua<CR>', { desc = 'Lua: execute current line' })
 vim.keymap.set('v', '<leader>x', '<Cmd>:lua<CR>', { desc = 'Lua: execute current selection' })
+
+-- Insert NOTE/TODO comments on a new line above the cursor using the buffer's commentstring
+local function insert_tagged_comment(tag)
+  local date = os.date(COMMENT_DATE_FORMAT)
+  local prefix = string.format('%s(%s %s): ', tag, COMMENT_AUTHOR, date)
+  local comment = vim.bo.commentstring:gsub('%%s', prefix)
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  local current_line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ''
+  local indent = current_line:match('^%s*') or ''
+  vim.api.nvim_buf_set_lines(0, row - 1, row - 1, false, { indent .. comment })
+  vim.api.nvim_win_set_cursor(0, { row, 0 })
+  vim.cmd('startinsert!')
+end
+
+vim.keymap.set('n', '<leader>in', function()
+  insert_tagged_comment('NOTE')
+end, { desc = 'Insert NOTE comment above' })
+
+vim.keymap.set('n', '<leader>it', function()
+  insert_tagged_comment('TODO')
+end, { desc = 'Insert TODO comment above' })
 
 -- GitHub permalinks
 vim.keymap.set('n', '<leader>gy', function()


### PR DESCRIPTION
## Why

When marking up code with `NOTE` or `TODO` annotations, manually typing the comment prefix, author, and date is repetitive and easy to format inconsistently. A dedicated keymap makes these annotations one-step and uniformly formatted.

## What

Adds two normal-mode keymaps in [lua/config/keymap.lua](lua/config/keymap.lua):

- `<leader>in` — insert a `NOTE(bmkiefer MM-DD-YYYY): ` comment on a new line above the cursor
- `<leader>it` — same, but `TODO`

Also adds a `Keymaps` section to [CLAUDE.md](CLAUDE.md) capturing a guideline to avoid `<leader>`-prefixed sequences whose keys share a finger on QWERTY.

## How

`insert_tagged_comment` builds the prefix from the tag, a `COMMENT_AUTHOR` constant, and `os.date(COMMENT_DATE_FORMAT)`, then substitutes it into the buffer's `commentstring` so the same keymap works across filetypes (Python, Lua, JS/TS, etc.). The new line copies the leading whitespace of the cursor's current line so indentation matches its surroundings, then `startinsert!` drops you in insert mode at the end of the comment ready to type the message.